### PR TITLE
get_percentage_values always returns 100 results

### DIFF
--- a/R/syuzhet.R
+++ b/R/syuzhet.R
@@ -194,13 +194,13 @@ get_transformed_values <- function(raw_values, low_pass_size = 3, x_reverse_len 
 #'
 get_percentage_values <- function(raw_values, bins = 100){
   if(!is.numeric(raw_values)) stop("Input must be a numeric vector")
-  chunk_size <- length(raw_values) / bins
-  if(chunk_size < 2){
-    stop("Input vector needs to be longer than 200 values to make percentage based segmentation viable")
+  if(length(raw_values)/bins < 2){
+    stop("Input vector needs to be twice as long as value number to make percentage based segmentation viable")
   }
-  x <- seq_along(raw_values)
-  chunks <- split(raw_values, ceiling(x/chunk_size))
-  unlist(lapply(chunks, mean))
+  chunks <- split(raw_values, cut(1:length(raw_values),100))
+  means = sapply(chunks, mean)
+  names(means) = 1:100
+  return(means)
 }
 
 #'  Get Sentiment from the Stanford Tagger


### PR DESCRIPTION
Fix for bug described at https://github.com/mjockers/syuzhet/issues/9. 

I also changed the code so that it checks relative to binsize for percentages rather than still assuming `bins==100`. 

I've tested the function itself, but perhaps not every place it's used.
